### PR TITLE
Guard against double registerMonitor calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ module.exports = FSMonitor;
 // It is possible for this module to be evaluated more than once in the same
 // heimdall session. In that case, we need to guard against double-counting by
 // making other instances of FSMonitor inert.
-var isMonitorRegistrar = false;
+var isMonitorRegistrant = false;
 var isFirstInstance = true;
 
 function FSMonitor() {
   this.state = 'idle';
   this.blacklist = ['createReadStream', 'createWriteStream', 'ReadStream', 'WriteStream'];
-  this._isEnabled = isMonitorRegistrar && isFirstInstance;
+  this._isEnabled = isMonitorRegistrant && isFirstInstance;
 
   // Flip this to false because we want other instances for the same heimdall
   // session to be inert.
@@ -39,8 +39,7 @@ FSMonitor.prototype.shouldMeasure = function() {
 
 if (!heimdall.hasMonitor('fs')) {
   heimdall.registerMonitor('fs', function FSSchema() {});
-
-  isMonitorRegistrar = true;
+  isMonitorRegistrant = true;
 }
 
 function Metric() {

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ function FSMonitor() {
   this.blacklist = ['createReadStream', 'createWriteStream', 'ReadStream', 'WriteStream'];
   this._isEnabled = isMonitorRegistrant && isFirstInstance;
 
-  // Flip this to false because we want other instances for the same heimdall
-  // session to be inert.
+  // Flip this to false because we want other instances from the same module to
+  // be inert.
   isFirstInstance = false;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var heimdall = require('heimdalljs');
+var logger = require('heimdalljs-logger')('heimdalljs-fs-monitor');
 module.exports = FSMonitor;
 
 // It is possible for this module to be evaluated more than once in the same
@@ -23,6 +24,10 @@ FSMonitor.prototype.start = function() {
   if (this._isEnabled) {
     this.state = 'active';
     this._attach();
+  } else {
+    logger.warn('Multiple instances of heimdalljs-fs-monitor have been created'
+      + ' in the same session. Since this can cause fs operations to be counted'
+      + ' multiple times, this instance has been disabled.');
   }
 };
 


### PR DESCRIPTION
Since it is possible that the fs-monitor could be included multiple times in a project through different dependencies, we need to guard against double registering via `registerMonitor`. This has the downside of making `statsFor` not return anything when we didn't register. In order to fix that, we make instances of `FSMonitor` essentially no-op since the alternative would result in double counting `fs` operations.

We control this via a shared `isEnabled` variable which acts kind of like a semaphore.