### PR TITLE
Fix `stop` to clean up fs properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
-var fs = require('fs');
-var heimdall = require('heimdalljs');
-var logger = require('heimdalljs-logger')('heimdalljs-fs-monitor');
+const fs = require('fs');
+const heimdall = require('heimdalljs');
+const logger = require('heimdalljs-logger')('heimdalljs-fs-monitor');
 module.exports = FSMonitor;
 
 // It is possible for this module to be evaluated more than once in the same
 // heimdall session. In that case, we need to guard against double-counting by
 // making other instances of FSMonitor inert.
-var isMonitorRegistrant = false;
-var hasActiveInstance = false;
+let isMonitorRegistrant = false;
+let hasActiveInstance = false;
 
 function FSMonitor() {
   this.state = 'idle';
@@ -56,7 +56,7 @@ Metric.prototype.start = function() {
 };
 
 Metric.prototype.stop = function() {
-  var now = process.hrtime();
+  let now = process.hrtime();
 
   this.time += (now[0] - this.startTime[0]) * 1e9 + (now[1] - this.startTime[1]);
   this.startTime = undefined;
@@ -74,8 +74,8 @@ FSMonitor.prototype._measure = function(name, original, context, args) {
     throw new Error('Cannot measure if the monitor is not active');
   }
 
-  var metrics = heimdall.statsFor('fs');
-  var m = metrics[name] = metrics[name] || new Metric();
+  let metrics = heimdall.statsFor('fs');
+  let m = metrics[name] = metrics[name] || new Metric();
 
   m.start();
 
@@ -87,39 +87,41 @@ FSMonitor.prototype._measure = function(name, original, context, args) {
   }
 };
 
+FSMonitor.prototype._monitorMember = function _monitorMember(member) {
+  let old = fs[member];
+  if (typeof old === 'function') {
+    fs[member] = (function(old, member) {
+      return function() {
+        if (this.shouldMeasure()) {
+          let args = new Array(arguments.length);
+          for (let i = 0; i < arguments.length; i++) {
+            args[i] = arguments[i];
+          }
+
+          return this._measure(member, old, fs, args);
+        } else {
+          return old.apply(fs, arguments);
+        }
+      };
+    }(old, member));
+
+    fs[member].__restore = function() {
+      fs[member] = old;
+    };
+  }
+};
+
 FSMonitor.prototype._attach = function() {
-  var monitor = this;
-
-  for (var member in fs) {
+  for (let member in fs) {
     if (this.blacklist.indexOf(member) === -1) {
-      var old = fs[member];
-      if (typeof old === 'function') {
-        fs[member] = (function(old, member) {
-          return function() {
-            if (monitor.shouldMeasure()) {
-              var args = new Array(arguments.length);
-              for (var i = 0; i < arguments.length; i++) {
-                args[i] = arguments[i];
-              }
-
-              return monitor._measure(member, old, fs, args);
-            } else {
-              return old.apply(fs, arguments);
-            }
-          };
-        }(old, member));
-
-        fs[member].__restore = function() {
-          fs[member] = old;
-        };
-      }
+      this._monitorMember(member);
     }
   }
 };
 
 FSMonitor.prototype._detach = function() {
-  for (var member in fs) {
-    var maybeFunction = fs[member];
+  for (let member in fs) {
+    let maybeFunction = fs[member];
     if (typeof maybeFunction === 'function' && typeof maybeFunction.__restore === 'function') {
       maybeFunction.__restore();
     }

--- a/tests.js
+++ b/tests.js
@@ -12,7 +12,6 @@ describe('FSMonitor', function() {
     expect(monitor0.state, 'monitor0 (m0 active)').to.eql('active');
     expect(monitor1.state, 'monitor1 (m0 active)').to.eql('idle');
 
-    debugger;
     monitor0.stop();
 
     monitor1.start();

--- a/tests.js
+++ b/tests.js
@@ -1,10 +1,14 @@
-var FSMonitor = require('./');
-var expect = require('chai').expect;
+/* global describe, it */
+
+const FSMonitor = require('./');
+const expect = require('chai').expect;
+const fs = require('fs');
+const originalStatSync = fs.statSync;
 
 describe('FSMonitor', function() {
   it('will only allow one active instance at a time', function() {
-    var monitor0 = new FSMonitor();
-    var monitor1 = new FSMonitor();
+    let monitor0 = new FSMonitor();
+    let monitor1 = new FSMonitor();
 
     monitor0.start();
     monitor1.start();
@@ -19,5 +23,22 @@ describe('FSMonitor', function() {
 
     expect(monitor0.state, 'monitor0 (m1 active)').to.eql('idle');
     expect(monitor1.state, 'monitor1 (m1 active)').to.eql('active');
+
+    monitor1.stop();
+    monitor0.stop();
+  });
+
+  describe('.prototype.stop', function() {
+    it('restores fs functions to their defaults', function() {
+      let monitor = new FSMonitor();
+
+      expect(fs.statSync).to.equal(originalStatSync);
+
+      monitor.start();
+      expect(fs.statSync).to.not.equal(originalStatSync);
+
+      monitor.stop();
+      expect(fs.statSync).to.equal(originalStatSync);
+    });
   });
 });


### PR DESCRIPTION
Previously it was reusing a local `member `variable within a closure, making every restore restore the same function.