### PR TITLE
Bump minimum heimdall version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "heimdalljs": "^0.2.0",
+    "heimdalljs": "^0.2.3",
     "heimdalljs-logger": "^0.1.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,12 @@ heimdalljs@^0.2.0:
   dependencies:
     rsvp "~3.2.1"
 
+heimdalljs@^0.2.3:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
+  dependencies:
+    rsvp "~3.2.1"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
Turns out the following commit: https://github.com/heimdalljs/heimdall-fs-monitor/commit/ee42f46656dadc04884f0fa3d75638f112c738d8 introduced a dependency on `heimdall.hasMonitor` which only became available in heimdall 0.2.2, but this project only depended on `^0.2.0`

In some unfortunate set of circumstances an incompatible version of heimdall could be pulled in.