### PR TITLE
Ensure `fs.Stats` (and other classes on `fs`) are not mutated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,15 @@ let hasActiveInstance = false;
 class FSMonitor {
   constructor() {
     this.state = 'idle';
-    this.blacklist = ['createReadStream', 'createWriteStream', 'ReadStream', 'WriteStream'];
+    this.blacklist = [
+      'createReadStream',
+      'createWriteStream',
+      'Dirent',
+      'FSWatcher',
+      'ReadStream',
+      'Stats',
+      'WriteStream'
+    ];
   }
 
   start() {


### PR DESCRIPTION
`fs.Stats` is a standard prototypal class (e.g. `function Stats() {}`), so it was being wrapped by our `fs` monitoring system. Unfortunately, wrapping `fs.Stats` in a plain function (which did `return original.apply(this, arguments)`) doesn't properly emulate a number of "standard" class behaviors. Specifically:

* static methods and properties are lost
* accessing `fs.Stats.prototype` does not refer to the original prototype

This last item was causing the following error when using `esm`:

```
TypeError: Function.prototype.apply was called on undefined, which is a undefined and not a function
    at $o (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:224377)
    at xu (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:226413)
    at wu (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:227391)
    at Eu (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:227999)
    at Module.<anonymous> (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:295976)
    at n (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/esm/esm.js:1:279589)
    at getFeatures (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/@ember-data/-build-infra/src/features.js:5:33)
    at Object.<anonymous> (/home/travis/build/ember-cli/ember-cli/tmp/node-FGpJBujF.tmp/node_modules/@ember-data/-build-infra/src/features.js:31:18)
```

This is because `esm` is _essentially_ doing:

```js
let isFile = fs.Stats.prototype.isFile;
```

To stash off the `isFile` implementation for recurring usage. The fact that when wrapped `fs.Stat.prototype.isFile` was undefined caused the error.